### PR TITLE
Fix: Prevent horizontal overflow on mobile view

### DIFF
--- a/src/components/motion/AnimatedPage.tsx
+++ b/src/components/motion/AnimatedPage.tsx
@@ -31,6 +31,7 @@ const AnimatedPage: React.FC<AnimatedPageProps> = ({ children, className }) => {
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -20 }} // Consistent exit animation
       transition={{ duration: 0.3 }} // Short and smooth duration
+      style={{ overflowX: 'hidden' }} // Added overflowX hidden
     >
       {children}
     </motion.div>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,6 +4,7 @@
 
 body {
   font-family: theme("fontFamily.sans");
+  overflow-x: hidden; /* Prevent horizontal overflow */
 }
 
 @layer utilities {


### PR DESCRIPTION
Applied `overflow-x: hidden` to `AnimatedPage` component and the global `body` style. This resolves an issue where content on the HomePage, particularly elements with absolute positioning or transformations, caused the page to overflow horizontally on mobile devices, making the fixed Navbar appear desbordado.