### PR TITLE
feat: Add JSON-LD schema for LocalBusiness

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,25 @@
       content="Entrenadora personal certificada en Jaén que ofrece programas de entrenamiento personalizados y asesoría nutricional."
     />
     <meta name="twitter:image" content="/social-preview.png" />
+
+    <!-- Schema.org / JSON-LD -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "LocalBusiness",
+        "name": "Gonorte – Entrenadora Personal",
+        "description": "Entrenadora personal certificada en Jaén que ofrece planes de entrenamiento personalizados, asesoría nutricional y clases online.",
+        "url": "https://luisotorres3.github.io/gonorte_2.0/",
+        "telephone": "+34 644 00 15 99",
+        "email": "gonorte.biomechanics@gmail.com",
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": "Jaén",
+          "addressCountry": "ES"
+        },
+        "image": "https://luisotorres3.github.io/gonorte_2.0/social-preview.png"
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Inserts a JSON-LD script block in the `<head>` of `index.html` to describe the business using Schema.org's `LocalBusiness` type.

This structured data helps search engines like Google understand the business details, which can lead to richer search results (e.g., local business cards).